### PR TITLE
Remove repeated query, set default to *

### DIFF
--- a/sidebarenhancer/SidebarEnhancerPlugin.php
+++ b/sidebarenhancer/SidebarEnhancerPlugin.php
@@ -3,7 +3,6 @@ namespace Craft;
 
 class SidebarEnhancerPlugin extends BasePlugin
 {
-
     public function getName()
     {
         return 'Sidebar enhancer';
@@ -73,14 +72,14 @@ class SidebarEnhancerPlugin extends BasePlugin
         return [
             'enabledFor' => [
                 AttributeType::Mixed,
-                'default' => craft()->sidebarEnhancer->getAdminUsernamesAsArray()
+                'default' => '*'
             ]
         ];
     }
 
     public function getSettingsHtml()
     {
-       return craft()->templates->render('sidebarenhancer/SidebarEnhancer_Settings', [
+        return craft()->templates->render('sidebarenhancer/SidebarEnhancer_Settings', [
            'settings' => $this->getSettings(),
            'admins' => craft()->sidebarEnhancer->getAdmins()
         ]);

--- a/sidebarenhancer/services/SidebarEnhancerService.php
+++ b/sidebarenhancer/services/SidebarEnhancerService.php
@@ -36,11 +36,11 @@ class SidebarEnhancerService extends BaseApplicationComponent
     {
         $user = craft()->userSession->getUser();
         $enabledFor = craft()->plugins->getPlugin('sidebarEnhancer')->getSettings()->enabledFor;
+        $isEnabled = $enabledFor === '*' || is_array($enabledFor) && in_array($user->username, $enabledFor);
 
         return craft()->request->isCpRequest()
             && $user
             && $user->admin
-            && is_array($enabledFor)
-            && in_array($user->username, $enabledFor);
+            && $isEnabled;
     }
 }

--- a/sidebarenhancer/templates/SidebarEnhancer_Settings.twig
+++ b/sidebarenhancer/templates/SidebarEnhancer_Settings.twig
@@ -16,7 +16,7 @@
             <div class="instructions"><p>Specify which admin(s) have the enhanced sidebar.</p></div>
         </div>
 
-        {{ forms.checkboxGroup({
+        {{ forms.checkboxSelect({
             id: 'enabledFor',
             name: 'enabledFor',
             options: options,


### PR DESCRIPTION
As mentioned in #8, it's a bad idea to perform queries in `defineSettings`, as that is going to get called on _every_ single request.

This PR changes the default to '*', which will allow any admin, at the time of saving settings or in the future, to have this settings.